### PR TITLE
TM:PE 11.1.1 will contain the update

### DIFF
--- a/Threading.cs
+++ b/Threading.cs
@@ -71,10 +71,10 @@ namespace CSURToolBox
                 DebugLog.LogToFileOnly("Detour LaneConnectorTool::CheckSegmentsTurningAngle calls");
                 try
                 {
-                    // Traffic manager is fixed in version 11.1.*
+                    // Traffic manager is fixed in version 11.1.1 and higher
                     // TODO delete this and NewLaneConnectorTool.cs when TMPE 11.0 [STABLE] has been depricated.
                     Version TMPE_Version = Assembly.Load("TrafficManager").GetName().Version;
-                    if(TMPE_Version < new Version(11, 1)) {
+                    if(TMPE_Version < new Version(11, 1, 1)) {
                         Loader.Detours.Add(new Loader.Detour(Assembly.Load("TrafficManager").GetType("TrafficManager.UI.SubTools.LaneConnectorTool").GetMethod("CheckSegmentsTurningAngle", BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(ushort), typeof(NetSegment).MakeByRefType(), typeof(bool), typeof(ushort), typeof(NetSegment).MakeByRefType(), typeof(bool) }, null),
                                            typeof(NewLaneConnectorTool).GetMethod("CheckSegmentsTurningAngle", BindingFlags.NonPublic | BindingFlags.Instance, null, new Type[] { typeof(ushort), typeof(NetSegment).MakeByRefType(), typeof(bool), typeof(ushort), typeof(NetSegment).MakeByRefType(), typeof(bool) }, null)));
                     }


### PR DESCRIPTION
A beta (11.1.0) is being pushed to LABS workshop page which does not yet contain the CSUR code; we need to get a bunch of other features out for users to test first.

11.1.1 should follow shortly after once we've had time to do full PR review.

Please let us know when this PR is merged and published to Steam Workshop so we can release the TM:PE 11.1.0 beta to LABS workshop without breaking CSUR compatibility.

Fixes krzychu124/Cities-Skylines-Traffic-Manager-President-Edition/issues/687