### PR TITLE
Fix unable to select the compact road while not subscribed express road

### DIFF
--- a/UI/MainUI.cs
+++ b/UI/MainUI.cs
@@ -316,31 +316,16 @@ namespace CSURToolBox.UI
         }
         public void hasSideWalkButton_OnCheckChanged()
         {
-            hasSidewalk = availableHasSidewalk;
-            hasBike = availableHasBike;
+            uint bit = (System.Convert.ToUInt32(availableHasSidewalk) << 1) + System.Convert.ToUInt32(availableHasBike);
             NetInfo nextModule = null;
-            if (hasSidewalk && hasBike)
+            for (int i = 0; i < 4; i++)
             {
-                nextModule = Parser.NetInfoFromUI(fromSelected, toSelected, availableSymmetry, false, false);
+                bit = (bit + 1) % 4;
+                hasSidewalk = System.Convert.ToBoolean(bit & 2);
+                hasBike = System.Convert.ToBoolean(bit & 1);
+                nextModule = Parser.NetInfoFromUI(fromSelected, toSelected, availableSymmetry, hasSidewalk, hasBike);
                 if (nextModule != null)
-                {
-                    hasSidewalk = false;
-                    hasBike = false;
-                }
-
-            } else if (!hasSidewalk && !hasBike)
-            {
-                nextModule = Parser.NetInfoFromUI(fromSelected, toSelected, availableSymmetry, true, false);
-                if (nextModule != null)
-                {
-                    hasSidewalk = true;
-                    hasBike = false;
-                }
-            }
-            if (nextModule == null)
-            {
-                hasSidewalk = true;
-                hasBike = true;
+                    break;
             }
         }
         private void RefreshDisplayData()


### PR DESCRIPTION
If the user not subscribed all type road, ToolBox unable to change the road type.
For example, the user is subscribed the 2DC、2DC compact, but ToolBox can't select 2DC compact, always select 2DC before subscribe 2DC express.